### PR TITLE
Fix mongo

### DIFF
--- a/deployment_scripts/deploy_apache_server.sh
+++ b/deployment_scripts/deploy_apache_server.sh
@@ -7,7 +7,7 @@ fi
 
 echo "adding apache to mongo and docker group"
 usermod -aG docker apache
-usermod -aG mongodb apache
+usermod -aG mongod apache
 
 mkdir -p /var/www/INGInious
 mkdir -p /var/www/INGInious/tasks

--- a/deployment_scripts/deploy_apache_server.sh
+++ b/deployment_scripts/deploy_apache_server.sh
@@ -15,9 +15,6 @@ mkdir -p /var/www/INGInious/backup
 mkdir -p /var/www/INGInious/tmp
 chown -R apache:apache /var/www/INGInious
 
-echo "setup permissions"
-sudo chown 777 -R /tmp
-
 echo "updating configuration files"
 current_path=$(pwd)
 echo "configuration.yaml"

--- a/deployment_scripts/install_mongodb.sh
+++ b/deployment_scripts/install_mongodb.sh
@@ -5,12 +5,12 @@ if [ "$EUID" -ne 0 ]
   exit
 fi
 
-touch /etc/yum.repos.d/mongodb.repo
+parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+cd "$parent_path"
 
-current_path=$(pwd)
-cp $current_path/config/mongodb.repo  /etc/yum.repos.d/
+cp ../config/mongodb.repo  /etc/yum.repos.d/
 
 yum -y install mongodb-org
 
-systemctl start mongod
-systemctl enable mongod
+systemctl start mongod.service
+systemctl enable mongod.service

--- a/deployment_scripts/install_mongodb.sh
+++ b/deployment_scripts/install_mongodb.sh
@@ -6,7 +6,6 @@ if [ "$EUID" -ne 0 ]
 fi
 
 touch /etc/yum.repos.d/mongodb.repo
-groupadd mongodb
 
 current_path=$(pwd)
 cp $current_path/config/mongodb.repo  /etc/yum.repos.d/


### PR DESCRIPTION
This PR fixes the service of mongod

Current behavior:
* mongod fails after apache is installed and when the machine is rebooted.
* mongod does not fail when the mahcine is rebooted if we don't execute ./run.sh

Causes:
* File `/tmp/mongodb-27017.sock` changes owner when the command `sudo chown 777 -R /tmp` is executed on `deploy_apache_server.sh` which is called by `./run.sh` 

Temporal fix:
* Delete the file `sudo rm -f /tmp/mongodb-27017.sock`. Then `sudo service mongod restart`. Mongo is going to create the file with the right owner and permissions

Permanent fix:
* Delete line `sudo chown 777 -R /tmp` from `deploy_apache_server.sh`  

Reason
* `sudo chown 777 -R /tmp`  is a buggy command, it is setting the owner of /tmp as the user 777 which does not exists. Maybe the author of the command meant `sudo *chmod* 777 -R /tmp`. However, by default /tmp is open to every user in the system so this command is not necesarry.

Patch tested on gcloud machines