### PR TITLE
Cokapi

### DIFF
--- a/deployment_scripts/cokapi.service
+++ b/deployment_scripts/cokapi.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Cokapi - Pythontutor backend for C++ and other languages
+StartLimitBurst=300
+StartLimitIntervalSec=600
+After=network.target
+
+[Service]
+User=ucokapi
+Group=ucokapi
+WorkingDirectory=/opt/tutor/OnlinePythonTutor/v4-cokapi
+ExecStart=/usr/local/bin/cokapi.sh
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/deployment_scripts/cokapi.sh
+++ b/deployment_scripts/cokapi.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-jshint cokapi.js && node cokapi.js
+node cokapi.js

--- a/deployment_scripts/cokapi.sh
+++ b/deployment_scripts/cokapi.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+jshint cokapi.js && node cokapi.js

--- a/deployment_scripts/deploy_cokapi_service.sh
+++ b/deployment_scripts/deploy_cokapi_service.sh
@@ -25,8 +25,6 @@ cd /opt/tutor/OnlinePythonTutor/v4-cokapi
 chown -R ucokapi:ucokapi /opt/tutor
 
 npm install express
-npm install -g jshint
-
 
 #Install systemd service
 cp $deployment_path/deployment_scripts/cokapi.sh /usr/local/bin

--- a/deployment_scripts/deploy_cokapi_service.sh
+++ b/deployment_scripts/deploy_cokapi_service.sh
@@ -11,8 +11,10 @@ id -u ucokapi > /dev/null 2>&1
 if [ $? -ne 0 ]
 then
     useradd ucokapi
-    usermod -aG ucokapi $(whoami)
 fi
+
+usermod -aG ucokapi $(whoami)
+usermod -aG docker ucokapi
 
 docker pull unjudge/opt-cpp-backend
 docker tag unjudge/opt-cpp-backend:latest pgbovine/opt-cpp-backend:v1

--- a/deployment_scripts/deploy_cokapi_service.sh
+++ b/deployment_scripts/deploy_cokapi_service.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+if [ "$EUID" -ne 0 ]
+  then echo "Please run as root"
+  exit
+fi
+
+docker pull unjudge/opt-cpp-backend
+docker tag unjudge/opt-cpp-backend:latest pgbovine/opt-cpp-backend:v1
+
+mkdir -p /opt/tutor
+cd /opt/tutor/
+
+git clone https://github.com/JuezUN/OnlinePythonTutor.git
+
+cd /opt/tutor/OnlinePythonTutor/v4-cokapi
+
+npm install express
+npm install -g jshint

--- a/deployment_scripts/deploy_cokapi_service.sh
+++ b/deployment_scripts/deploy_cokapi_service.sh
@@ -27,13 +27,13 @@ npm install -g jshint
 
 
 #Install systemd service
-cd "$(dirname "$0")"
+current_path=$(pwd)
 
-cp cokapi.sh /usr/local/bin
+cp $current_path/deployment_scripts/cokapi.sh /usr/local/bin
 chown ucokapi:ucokapi /usr/local/bin/cokapi.sh
 chmod +x /usr/local/bin/cokapi.sh
 
-cp cokapi.service /etc/systemd/system
+cp $current_path/deployment_scripts/cokapi.service /etc/systemd/system
 chmod 664 /etc/systemd/system/cokapi.service
 
 systemctl daemon-reload

--- a/deployment_scripts/deploy_cokapi_service.sh
+++ b/deployment_scripts/deploy_cokapi_service.sh
@@ -24,3 +24,18 @@ chown -R ucokapi:ucokapi /opt/tutor
 
 npm install express
 npm install -g jshint
+
+
+#Install systemd service
+cd "$(dirname "$0")"
+
+cp cokapi.sh /usr/local/bin
+chown ucokapi:ucokapi /usr/local/bin/cokapi.sh
+chmod +x /usr/local/bin/cokapi.sh
+
+cp cokapi.service /etc/systemd/system
+chmod 664 /etc/systemd/system/cokapi.service
+
+systemctl daemon-reload
+systemctl enable cokapi.service
+systemctl start cokapi.service

--- a/deployment_scripts/deploy_cokapi_service.sh
+++ b/deployment_scripts/deploy_cokapi_service.sh
@@ -5,6 +5,8 @@ if [ "$EUID" -ne 0 ]
   exit
 fi
 
+deployment_path=$(pwd)
+
 id -u ucokapi > /dev/null 2>&1
 if [ $? -ne 0 ]
 then
@@ -27,13 +29,11 @@ npm install -g jshint
 
 
 #Install systemd service
-current_path=$(pwd)
-
-cp $current_path/deployment_scripts/cokapi.sh /usr/local/bin
+cp $deployment_path/deployment_scripts/cokapi.sh /usr/local/bin
 chown ucokapi:ucokapi /usr/local/bin/cokapi.sh
 chmod +x /usr/local/bin/cokapi.sh
 
-cp $current_path/deployment_scripts/cokapi.service /etc/systemd/system
+cp $deployment_path/deployment_scripts/cokapi.service /etc/systemd/system
 chmod 664 /etc/systemd/system/cokapi.service
 
 systemctl daemon-reload

--- a/deployment_scripts/deploy_cokapi_service.sh
+++ b/deployment_scripts/deploy_cokapi_service.sh
@@ -5,15 +5,22 @@ if [ "$EUID" -ne 0 ]
   exit
 fi
 
+id -u ucokapi > /dev/null 2>&1
+if [ $? -ne 0 ]
+then
+    useradd ucokapi
+    usermod -aG ucokapi $(whoami)
+fi
+
 docker pull unjudge/opt-cpp-backend
 docker tag unjudge/opt-cpp-backend:latest pgbovine/opt-cpp-backend:v1
 
 mkdir -p /opt/tutor
 cd /opt/tutor/
-
 git clone https://github.com/JuezUN/OnlinePythonTutor.git
-
 cd /opt/tutor/OnlinePythonTutor/v4-cokapi
+
+chown -R ucokapi:ucokapi /opt/tutor
 
 npm install express
 npm install -g jshint

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,10 +11,3 @@ services:
     ports:
       - "${PYTHON_TUTOR_PORT}:8003"
     restart: always
-  cokapi:
-    image: unjudge/cokapi
-    ports:
-      - "${COKAPI_PORT}:3000"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    restart: always

--- a/run.sh
+++ b/run.sh
@@ -16,3 +16,4 @@ fi
 
 sudo bash deployment_scripts/deploy_nginx_server.sh
 sudo bash deployment_scripts/deploy_lighttpd_server.sh
+sudo bash deployment_scripts/deploy_cokapi_service.sh


### PR DESCRIPTION
This PR removes cokapi from docker-compose because it shouldn't be dockerized. It uses docker to compile and execute code from the students and therefore, it cannot be easily dockerized. It is wiser to treat it as a system level service just as mongo, nginx and lighttpd

Changes

* Removed cokapi from docker-compose.yml
* Created installation logic of cokapi as a system level service
* cokapi installation logic is called in run.sh file
