### PR TITLE
Deployment home env

### DIFF
--- a/setup_environment.sh
+++ b/setup_environment.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
+echo -e "export DEPLOYMENT_HOME=\"$(pwd)\"\n" >> env.sh
+
 cp env.sh ~/.uncode_env
 echo 'source ~/.uncode_env' >> ~/.bashrc

--- a/uncode_scripts/readme.md
+++ b/uncode_scripts/readme.md
@@ -35,10 +35,8 @@ This command is used to restart the web application, it restarts the services of
 Usage:
 
 ``` 
-sudo uncode_webapp_restart
+uncode_webapp_restart
 ```
-
-Note that **sudo** is required because we are restarting system level services.
 
 ## uncode_linter_restart
 

--- a/uncode_scripts/readme.md
+++ b/uncode_scripts/readme.md
@@ -40,12 +40,11 @@ uncode_webapp_restart
 
 ## uncode_linter_restart
 
-This command is used to **update and restart** the linter web service. Important: the current working directory when executing this script must be the root of the Deployment repository folder because it contains the file `docker-compose.yml` which is needed by the script. If the image is already up to date, then it only restarts the service.
+This command is used to **update and restart** the linter web service.
 
 Usage: 
 
 ```
-cd /path/to/Deployment/folder
 uncode_linter_restart
 ```
 
@@ -56,7 +55,6 @@ This command is used to update and restart the tutor services which are python-t
 Usage: 
 
 ```
-cd /path/to/Deployment/folder
 uncode_tutor_restart
 ```
 

--- a/uncode_scripts/uncode_full_restart
+++ b/uncode_scripts/uncode_full_restart
@@ -4,7 +4,7 @@ set -e
 
 echo "Full restart of UNCode started"
 
-sudo uncode_webapp_restart
+uncode_webapp_restart
 uncode_linter_restart
 uncode_tutor_restart
 

--- a/uncode_scripts/uncode_linter_restart
+++ b/uncode_scripts/uncode_linter_restart
@@ -1,9 +1,6 @@
 #!/bin/bash
 
-if [ ! -f docker-compose.yml ]; then
-    echo "docker-compose.yml not found, cd into to Deployment folder."
-    exit
-fi
+cd $DEPLOYMENT_HOME
 
 echo "Updating and restarting linter-web-service..."
 docker-compose up -d --no-deps linter-service

--- a/uncode_scripts/uncode_tutor_restart
+++ b/uncode_scripts/uncode_tutor_restart
@@ -1,9 +1,6 @@
 #!/bin/bash
 
-if [ ! -f docker-compose.yml ]; then
-    echo "docker-compose.yml not found, cd into to Deployment folder."
-    exit
-fi
+cd $DEPLOYMENT_HOME
 
 #Restart and update docker container
 echo "Updating and restarting python-tutor..."

--- a/uncode_scripts/uncode_webapp_restart
+++ b/uncode_scripts/uncode_webapp_restart
@@ -1,19 +1,13 @@
 #!/bin/bash
-
-if [ "$EUID" -ne 0 ]
-  then echo "Please run as root"
-  exit
-fi
-
 echo "Restarting uncode..."
 
 echo "Restarting lighttpd 1/3"
-service lighttpd restart
+sudo service lighttpd restart
 
 echo "Restarting nginx 2/3"
-service nginx restart
+sudo service nginx restart
 
 echo "Restarting mongod 3/3"
-service mongod restart
+sudo service mongod restart
 
 echo "Uncode restarted successfully"


### PR DESCRIPTION
This PR's objective is to simplify the use of the management scripts that are related to docker-compose services. We store in a variable called DEPLOYMENT_HOME the directory which the Deployment repository is located. We do this automatically when setting the environment variables for the rest of the application. So the installation process is left unchanged.

So you no longer need to cd into the Deployment folder because the script does it by itself