### PR TITLE
Maintenance page

### DIFF
--- a/config/maintenance_off.html
+++ b/config/maintenance_off.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>Site Maintenance</title>
+<style>
+  body { text-align: center; padding: 150px; }
+  h1 { font-size: 50px; }
+  body { font: 20px Helvetica, sans-serif; color: #333; }
+  article { display: block; text-align: left; width: 650px; margin: 0 auto; }
+  a { color: #dc8100; text-decoration: none; }
+  a:hover { color: #333; text-decoration: none; }
+</style>
+
+<article>
+    <h1>We&rsquo;ll be back soon!</h1>
+    <div>
+        <p>Sorry for the inconvenience but we&rsquo;re performing some maintenance at the moment.
+            we&rsquo;ll be back online shortly!</p>
+        <p>&mdash; UNCode Team</p>
+    </div>
+</article>

--- a/config/nginx/conf.d/inginious.conf
+++ b/config/nginx/conf.d/inginious.conf
@@ -31,7 +31,7 @@ server {
   location / {
       if (-f $document_root/maintenance_on.html) {
         return 503;
-      }}
+      }
       proxy_pass http://localhost:8088/;
       proxy_set_header Host               $host;
       proxy_http_version 1.1;

--- a/config/nginx/conf.d/inginious.conf
+++ b/config/nginx/conf.d/inginious.conf
@@ -29,6 +29,9 @@ server {
   }
 
   location / {
+      if (-f $document_root/maintenance_on.html) {
+        return 503;
+      }}
       proxy_pass http://localhost:8088/;
       proxy_set_header Host               $host;
       proxy_http_version 1.1;
@@ -37,5 +40,9 @@ server {
       proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto  $scheme;
       # If you need to set more headers, go to lighttpd.conf file in order to trust those headers.
+  }
+
+  error_page 503 /maintenance_on.html;
+      location = /maintenance_on.html {
   }
 }

--- a/deployment_scripts/deploy_nginx_server.sh
+++ b/deployment_scripts/deploy_nginx_server.sh
@@ -10,5 +10,7 @@ current_path=$(pwd)
 rm -rf /etc/nginx
 cp -r $current_path/config/nginx /etc/
 
+cp $current_path/config/maintenance_off.html /usr/share/nginx/html/
+
 systemctl enable nginx
 systemctl restart nginx

--- a/uncode_scripts/readme.md
+++ b/uncode_scripts/readme.md
@@ -8,6 +8,27 @@ Otherwise if you called `install_prerequisites.sh` script, they are already inst
 
 If you call the command again (with either option), the scripts will be updated with whatever version you have in the Deployment repository.
 
+## uncode_maintenance_window
+
+This command activates a maintenance window page so users know when we are 
+in maintenance. This page is shown via nginx.
+
+Usage:
+
+#### Activate
+To activate the maintenance window and show the page, run the command:
+
+``` 
+uncode_maintenance_window activate 
+```
+
+#### Deactivate
+To deactivate the maintenance window and stop showing the page, run the command:
+
+``` 
+uncode_maintenance_window deactivate 
+```
+
 ## uncode_status
 
 Shows the output of the `top` command but filtered to the processes related with UNCode. It is useful for monitoring proposes.

--- a/uncode_scripts/uncode_maintenance_window
+++ b/uncode_scripts/uncode_maintenance_window
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-if [ "$1" == "active" ]
+if [ "$1" == "activate" ]
 then
-  mv /usr/share/nginx/html/maintenance_off.html /usr/share/nginx/html/maintenance_on.html
-elif [ "$1" == "deactive" ]
+  sudo mv /usr/share/nginx/html/maintenance_off.html /usr/share/nginx/html/maintenance_on.html
+elif [ "$1" == "deactivate" ]
 then
-  mv /usr/share/nginx/html/maintenance_on.html /usr/share/nginx/html/maintenance_off.html
+  sudo mv /usr/share/nginx/html/maintenance_on.html /usr/share/nginx/html/maintenance_off.html
 else
-  echo "Usage: the only options available are 'active' and 'deactive'."
+  echo "Usage: the only options available are 'activate' and 'deactivate'."
 fi

--- a/uncode_scripts/uncode_maintenance_window
+++ b/uncode_scripts/uncode_maintenance_window
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ "$1" == "active" ]
+then
+  mv /usr/share/nginx/html/maintenance_off.html /usr/share/nginx/html/maintenance_on.html
+elif [ "$1" == "deactive" ]
+then
+  mv /usr/share/nginx/html/maintenance_on.html /usr/share/nginx/html/maintenance_off.html
+else
+  echo "Usage: the only options available are 'active' and 'deactive'."
+fi


### PR DESCRIPTION
Add maintenance page option in Nginx to show page when maintenance window is happening.
Additionally, adds an _uncode_ script `uncode_maintenance_window` to `activate` and `deactivate` the window easily.

This page looks like:
![image](https://user-images.githubusercontent.com/22863695/67153251-61768f00-f2ab-11e9-8678-7c2845f8fe9b.png)

Fix #47 