### PR TITLE
Remove python tutor 2 container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,11 +14,3 @@ services:
     ports:
       - "${PYTHON_TUTOR_PORT}:8003"
     restart: always
-  python-tutor-py2:
-    image: unjudge/onlinepythontutor_py2
-    environment:
-      - COKAPI_ENDPOINT=uncode.unal.edu.co/cokapi
-      - PY_CMD=python
-    ports:
-      - "${PYTHON_PY2_TUTOR_PORT}:8003"
-    restart: always


### PR DESCRIPTION
As python 2 support is removed, the python tutor 2 container deployment is removed as well.