### PR TITLE
Add cpu limit to linter service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       resources:
         limits:
           memory: 3000M # Limit memory usage to 3GB
+          cpus: "2" # Set a custom memory usage
   python-tutor:
     image: unjudge/onlinepythontutor
     environment:


### PR DESCRIPTION
# Description

Limit the cpu usage for the linter service as it uses a lot of cpu.

## Type of change

Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
