### PR TITLE
Add a fourth parameter to tell the script whether to push commits or not

### DIFF
--- a/uncode_scripts/README.md
+++ b/uncode_scripts/README.md
@@ -255,11 +255,12 @@ uncode_update_containers
 
 Use this script to create backups of configuration files for a given server. This script copies some specific configuration files from the different services hosted by a given server. The files are copied to Git repository. Thus, you need to have a repository where you want to store the backed up files.
 
-This script receives three mandatory parameters:
+This script receives 4 mandatory parameters:
 
 1. Path to the repository: this first parameter tells the script where to copy the files.
 2. Server name: a name that you give to the server you are backing up. For example `main` or `grader-1`.
 3. Server type: given that the same repository may be used to store config files from several servers, it is necessary to tell the script what kind of services are hosted in that server. Thus, you need to write either `main`, `grader` or `tools`, which are the kinds of services that can be deployed with UNCode.
+4. A flag indicating whether to make a push or not.
 
 These services or files are backed up:
 
@@ -276,5 +277,5 @@ As seen in the list, the kind of service that is backed up, directly depends on 
 To use this script, run the next command, replacing the parameters with the correct values:
 
 ```bash
-uncode_config_files_backup /path/to/repository <server_name> <server_type (main/grader/tools)>
+uncode_config_files_backup /path/to/repository <server_name> <server_type (main/grader/tools)> <true/false>
 ```

--- a/uncode_scripts/uncode_config_files_backup
+++ b/uncode_scripts/uncode_config_files_backup
@@ -29,13 +29,15 @@ backup_folder_path="$1";
 server_name="$2";
 server_type="$3";
 
+make_push="$4";
+
 dt=$(date '+%d/%m/%Y %H:%M:%S');
 
 cd "$backup_folder_path";
 mkdir "$server_name" || true;
 cd "$server_name/";
 
-sudo git pull origin master
+sudo git pull origin master || true;
 
 rm -f backup.log || true;
 
@@ -129,8 +131,11 @@ sudo git commit -m "$dt"
 
 echo -e "\nBackup committed successfully\n";
 
-echo -e "\nPushing backups to remote...\n"
+if ["$make_push" == "true"]
+then
+    echo -e "\nPushing backups to remote...\n"
 
-sudo git push -u origin master
+    sudo git push -u origin master
 
-echo -e "\nBackup(s) pushed successfully"
+    echo -e "\nBackup(s) pushed successfully"
+end


### PR DESCRIPTION
# Description

This change is necessary when the server cannot connect to the remote repository, thus, only one machine will make the push and the local git repo is shared across the servers.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
