### PR TITLE
Add fixes on agent

### DIFF
--- a/agent/deploy_agent_services.sh
+++ b/agent/deploy_agent_services.sh
@@ -30,6 +30,8 @@ chown agent:agent /usr/local/bin/mcq_agent.sh
 cp "$DEPLOYMENT_HOME/agent/units/docker_agent.service" "/etc/systemd/system"
 cp "$DEPLOYMENT_HOME/agent/units/mcq_agent.service" "/etc/systemd/system"
 
+touch /etc/sysconfig/agents_env.conf
+
 # Set proxy in case it is present
 if [ -n "$http_proxy" ]
 then

--- a/agent/docker_agent.sh
+++ b/agent/docker_agent.sh
@@ -5,4 +5,10 @@
 # The first parameter is the backendhost IP and the second parameter is the concurrency which indicates how many
 # cores will run submission concurrently.
 
-inginious-agent-docker tcp://$(grep backendhost < /etc/hosts | awk 'NR==1{print $1}'):2001 --concurrency $(($(nproc) - 1)) --debug-host $(hostname -I | awk 'NR==1{print $1}')
+number_cpus=$(($(nproc) - 1));
+
+if [ "$number_cpus" -eq "0" ]; then
+    number_cpus=1;
+fi
+
+inginious-agent-docker tcp://$(grep backendhost < /etc/hosts | awk 'NR==1{print $1}'):2001 --concurrency $number_cpus --debug-host $(hostname -I | awk 'NR==1{print $1}')


### PR DESCRIPTION
# Description

We detected some small bugs when installing the container agents of UNCode:
- When there is no proxy, the file `/etc/sysconfig/agents_env.conf` is not created and the `docker_agent` and `mcq_agent` services don't work.
- When the `docker_agent` is installed in a machine with only one cpu, the concurrency is set to 0 and the service is not started.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
