### PR TITLE
remove dangling images every week

### DIFF
--- a/uncode_scripts/uncode_update_containers
+++ b/uncode_scripts/uncode_update_containers
@@ -29,3 +29,5 @@ docker tag unjudge/inginious-c-multilang ingi/inginious-c-multilang
 docker tag unjudge/inginious-c-datascience ingi/inginious-c-datascience
 docker tag unjudge/hdl-uncode ingi/hdl-uncode
 docker tag unjudge/inginious-c-notebook ingi/inginious-c-notebook
+
+docker rmi $(docker images --filter "dangling=true" -q --no-trunc)


### PR DESCRIPTION
# Description

The scripts responsible for updating the containers every week were updated with a simple instruction to remove all "dangling" images. A dangling image is produced when the newer docker image is pulled and tagged with the same tag as a pre-existing one. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The codeline was executed once manually in the servers to free disk space, however, it was considered best to make its execution automatic on a weekly basis

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
